### PR TITLE
Update startup conditions - Minio

### DIFF
--- a/minio/egg-minio-s3.json
+++ b/minio/egg-minio-s3.json
@@ -17,7 +17,7 @@
     "startup": ".\/minio.sh",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\"\r\n}",
+        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"}",
         "logs": "{}",
         "stop": "^C"
     },

--- a/minio/egg-minio-s3.json
+++ b/minio/egg-minio-s3.json
@@ -17,7 +17,7 @@
     "startup": ".\/minio.sh",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"}",
+        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },

--- a/minio/egg-pterodactyl-minio-s3.json
+++ b/minio/egg-pterodactyl-minio-s3.json
@@ -17,7 +17,7 @@
     "config": {
         "files": "{}",
         "logs": "{}",
-        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"}",
+        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"\r\n}",
         "stop": "^C"
     },
     "scripts": {

--- a/minio/egg-pterodactyl-minio-s3.json
+++ b/minio/egg-pterodactyl-minio-s3.json
@@ -17,7 +17,7 @@
     "config": {
         "files": "{}",
         "logs": "{}",
-        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\"\r\n}",
+        "startup": "{\r\n    \"done\": \"guide\",\r\n    \"done\": \"Documentation:\",\r\n    \"done\": \"Docs:\"}",
         "stop": "^C"
     },
     "scripts": {


### PR DESCRIPTION
Minio has switched from `Documentation` to using `Docs`, not sure which version they did this (I'm running `RELEASE.2025-07-23T15-54-02Z`), I just realized because my minio never switched to "running"

I have tested this on my own Pelican panel (see picture below)
<img width="1248" height="647" alt="image" src="https://github.com/user-attachments/assets/eb2892a0-75ba-4b59-87d0-4de8fcfe1c2a" />